### PR TITLE
Don't eat = characters in configuration values

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,7 @@ mod parser {
                 return Parsed::Error("incorrect section syntax".to_owned());
             }
         } else if content.contains('=') {
-            let mut pair = content.split('=').map(|s| s.trim());
+            let mut pair = content.splitn(2, '=').map(|s| s.trim());
             let key = pair.next().unwrap().to_owned();
             let value = pair.next().unwrap().to_owned();
             return Parsed::Value(key, value);


### PR DESCRIPTION
When a configuration value contains an = character, it is currently dropped along what follows it.
