### PR TITLE
Sections separated with a single blank line in output

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,7 +302,7 @@ impl fmt::Display for Ini {
                 buffer.push_str(&format!("{} = {}\n", key, value));
             }
             // blank line between sections
-            buffer.push_str("\n")
+            buffer.push_str("\n");
         }
         // remove last '\n'
         buffer.pop();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ impl Ini {
     /// // or format!("{}", conf);
     /// // let value: String = format!("{}", conf);
     /// // but the result will be the same
-    /// assert_eq!(value, "[section]\none = 1".to_owned());
+    /// assert_eq!(value, "[section]\none = 1\n".to_owned());
     /// ```
     pub fn to_buffer(&self) -> String {
         format!("{}", self)
@@ -301,6 +301,8 @@ impl fmt::Display for Ini {
             for (key, value) in iter {
                 buffer.push_str(&format!("{} = {}\n", key, value));
             }
+            // blank line between sections
+            buffer.push_str("\n")
         }
         // remove last '\n'
         buffer.pop();


### PR DESCRIPTION
Hi!  

Thank you for making this library. It is the only rust ini lib I found that would let me easily store regex patterns in values.

I am hacking on an application that reads an ini file, but then also regenerates the ini file, and it would be much prettier if sections could be separate by a single blank line when saving the ini data, e.g.

```
[section]
blah = 123

[section]
bleh = 456
```

Currently, it saves with no blank lines.  In my PR, I've left a single `\n` at the end and modified a test to allow this; but let me know if you really do want there to be no newlines at the end.  Many text editors will append a newline to a text file automatically so it seems more common to have it, than not.