### PR TITLE
Iterating over Ini yields "Section" type instead of "SectionIter"  (2.0 - breaking change)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -492,8 +492,7 @@ impl Ini {
     /// assert_eq!(conf.section_iter("absent").count(), 0);
     /// ```
     pub fn section_iter(&self, section: &str) -> SectionIter {
-        let section = self.document.get(section).unwrap_or(&self.empty_section);
-        SectionIter { document: &section, iter: section.iter() }
+        SectionIter { iter: self.document.get(section).unwrap_or(&self.empty_section).iter() }
     }
 
     /// Iterate over all sections in order of appearance, yielding pairs of
@@ -583,7 +582,7 @@ impl<'a> Iterator for IniIter<'a> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(|(name, section)| (name, SectionIter { document: &section, iter: section.iter() }))
+        self.iter.next().map(|(name, section)| (name, SectionIter { iter: section.iter() }))
     }
 }
 
@@ -607,7 +606,6 @@ type Section = OrderedHashMap<String, String>;
 /// An iterator over the entries of a section
 pub struct SectionIter<'a> {
     #[doc(hidden)]
-    document: &'a Section,
     iter: ordered_hashmap::Iter<'a, String, String>,
 }
 
@@ -616,12 +614,6 @@ impl<'a> Iterator for SectionIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
-    }
-}
-
-impl<'a> SectionIter<'a> {
-    pub fn get(&'a self, key: &str) -> Option<&'a String> {
-        self.document.get(key)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -620,27 +620,8 @@ impl<'a> Iterator for SectionIter<'a> {
 }
 
 impl<'a> SectionIter<'a> {
-    /// Get scalar value of key
-    ///
-    /// - output type `T` must implement [FromStr] trait for auto conversion
-    ///
-    /// # Example
-    /// ```
-    /// # use tini::Ini;
-    /// let conf = Ini::from_string("[section]\nkey=1\nvalue=2").unwrap();
-    ///
-    /// for (name, section) in conf.iter() {
-    ///     let key = section.get("key");
-    ///     let value = section.get("value");
-    ///     assert_eq!(key, Some(1));
-    ///     assert_eq!(value, Some(2));
-    /// }
-    /// ```
-    pub fn get<T>(&'a self, key: &str) -> Option<T>
-    where
-        T: FromStr,
-    {
-        self.document.get(key).and_then(|x| x.parse().ok())
+    pub fn get(&'a self, key: &str) -> Option<&'a String> {
+        self.document.get(key)
     }
 }
 

--- a/src/ordered_hashmap.rs
+++ b/src/ordered_hashmap.rs
@@ -250,17 +250,6 @@ where
     }
 }
 
-impl<K, V> IntoIterator for OrderedHashMap<K, V>
-where
-    K: Eq + Hash,
-{
-    type Item = (K, V);
-    type IntoIter = IntoIter<K, V>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        IntoIter { base: self.base, keys_iterator: self.keys.into_iter() }
-    }
-}
 
 impl<K, V> FromIterator<(K, V)> for OrderedHashMap<K, V>
 where


### PR DESCRIPTION
From the previous discussion here: https://github.com/pinecrew/tini/issues/35

I have no expectations about this being merged quickly or anything since it's a change for 2.0, I just wanted to put this out early for review at your leisure.

I expect that the API still needs some improvement and I might have missed some things in the docs.  I'll come back to it eventually.